### PR TITLE
Fix parsing of octal escapes

### DIFF
--- a/lib/minjs/lex.rb
+++ b/lib/minjs/lex.rb
@@ -622,11 +622,12 @@ module Minjs
         # octal
         # Annex B
         if octal?(@codes[@pos])
-          oct = 0
-          while octal?(@codes[@pos])
+          oct = (@codes[@pos] - 0x30)
+          2.times do
+            break unless octal?(@codes[@pos+1])
+            @pos += 1
             oct *= 8
             oct += (@codes[@pos] - 0x30)
-            @pos += 1
           end
           [oct].pack("U*")
         else

--- a/spec/literal/string_spec.rb
+++ b/spec/literal/string_spec.rb
@@ -13,7 +13,17 @@ a="a\x42c"
 a="a\102c"
 a="あいうえお"
 EOS
-      expect(js).to eq('a="";a="abc";a="a\nbc";a="aBc";a="aBc";a="aB";a="あいうえお";')
+      expect(js).to eq('a="";a="abc";a="a\nbc";a="aBc";a="aBc";a="aBc";a="あいうえお";')
+    end
+
+    it 'handles octal literals correctly' do
+      js = test_parse <<-'EOS'
+a = '\0'
+a = "\10"
+a = "\100"
+a = "\1000"
+EOS
+      expect(js).to eq("a=\"\\0\";a=\"\\b\";a=\"@\";a=\"@0\";")
     end
   end
 end


### PR DESCRIPTION
The previous parsing of octal escapes broke when the last character
in the string was an octal escape, and silently ate the character
after the octal escape otherwise. This is because it didn't reset
the position correctly.

Additionally, octal escapes were not limited to three characters,
which results in incorrect handling if the character after the
octal escape is also a valid octal character.

This fixes both issues.
