### PR TITLE
Work with ruby 2.3's --enable-frozen-string-literal

### DIFF
--- a/lib/minjs/ecma262/literal.rb
+++ b/lib/minjs/ecma262/literal.rb
@@ -427,9 +427,9 @@ module Minjs
         dq = @val.to_s.each_codepoint.select{|x| x == 0x22}.length
         sq = @val.to_s.each_codepoint.select{|x| x == 0x27}.length
         if dq <= sq
-          t = "\""
+          t = "\"".dup
         else
-          t = "\'"
+          t = "\'".dup
         end
 
         @val.to_s.each_codepoint do |c|


### PR DESCRIPTION
These changes are the minimal ones necessary to allow Roda's specs
to pass. There may well be other changes that are required.
